### PR TITLE
docs: add docs about Vite config

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,23 +57,16 @@ export default {
 You can pass Vite configurations and plugins into the `vite` entry of `nuxt.config`
 
 ```js
-import ViteWindiCSS from 'vite-plugin-windicss'
-
 // nuxt.config
 export default {
   buildModules: [
     'nuxt-vite'
   ],
   vite: {
-    plugins: [
-      ViteWindiCSS()
-    ],
-    /* options for vite-plugin-vue2 */
+    /* options for vite */
     vue: {
-      vueTemplateOptions: { /* ... */ },
-      jsx: true,
+      /* options for vite-plugin-vue2 */
     },
-    /* ... */
   }
 }
 ```
@@ -101,7 +94,7 @@ Currently using a fork of vite to address this issue. If still having, please ad
 
 ### `.gql` support
 
-Curretnly there is no module support for handling gql files ([#31](https://github.com/nuxt/vite/issues/31)).
+Currently there is no module support for handling gql files ([#31](https://github.com/nuxt/vite/issues/31)).
 
 Best solution for now is to wrap gql code into `js` or `ts` and using [graphql-tag](https://www.npmjs.com/package/graphql-tag) or using raw GraphQL queries. Remember to add `loc.source.body`.
 

--- a/README.md
+++ b/README.md
@@ -68,12 +68,17 @@ export default {
     plugins: [
       ViteWindiCSS()
     ],
+    /* options for vite-plugin-vue2 */
+    vue: {
+      vueTemplateOptions: { /* ... */ },
+      jsx: true,
+    },
     /* ... */
   }
 }
 ```
 
-More details refer to [Vite's documentations](https://vitejs.dev/config/).
+More details refer to [Vite's documentations](https://vitejs.dev/config/) and [`vite-plugin-vue2`](https://github.com/underfin/vite-plugin-vue2).
 
 ## 🐛 Common Issues
 

--- a/README.md
+++ b/README.md
@@ -52,13 +52,36 @@ export default {
 
 **Note:** Nuxt >= 2.15.0 is required
 
+## 💡 Vite Config
+
+You can pass Vite configurations and plugins into the `vite` entry of `nuxt.config`
+
+```js
+import ViteWindiCSS from 'vite-plugin-windicss'
+
+// nuxt.config
+export default {
+  buildModules: [
+    'nuxt-vite'
+  ],
+  vite: {
+    plugins: [
+      ViteWindiCSS()
+    ],
+    /* ... */
+  }
+}
+```
+
+More details refer to [Vite's documentations](https://vitejs.dev/config/).
+
 ## 🐛 Common Issues
 
 **💡 Take a look at [issues](https://github.com/nuxt/vite/issues) for known issues and workarounds**
 
 ### `Can't find loader handling '.vue' files`
 
-While we added a workaround to mitigate this, vite recommands explicitly defining extensions for non javascript assets.
+While we added a workaround to mitigate this, vite recommends explicitly defining extensions for non javascript assets.
 
 ```diff
 - import MyComponent from '~/components/MyComponent'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,8 @@
 import type { } from '@nuxt/types'
-import type { VueViteOptions } from 'vite-plugin-vue2'
-import type { UserConfig } from 'vite'
 import { resolve } from 'upath'
 import semver from 'semver'
 import { name, version } from '../package.json'
+import type { ViteInlineConfig } from './types'
 
 function nuxtVite () {
   const { nuxt } = this
@@ -58,6 +57,13 @@ export default nuxtVite
 
 declare module '@nuxt/types/config/index' {
   interface NuxtOptions {
-    vite?: UserConfig & { vue?: VueViteOptions }
+    /**
+     * Configuration for Vite.
+     * Severe the same functionality as Vite's `vite.config.ts`.
+     * It will merges with Nuxt specify configurations and plugins.
+     *
+     * @link https://vitejs.dev/config/
+     */
+    vite?: ViteInlineConfig
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,11 @@ export interface Nuxt {
 }
 
 export interface ViteInlineConfig extends InlineConfig {
+  /**
+   * Options for vite-plugin-vue2
+   *
+   * @link https://github.com/underfin/vite-plugin-vue2
+   */
   vue?: VueViteOptions
 }
 


### PR DESCRIPTION
I am not sure if it's ok to demo the config with some really plugins or we should use placeholders like `vite-plugin-foo`. Use `vite-plugin-windicss` for now as #24, happy to change if you have any idea on this tho. Thanks