### PR TITLE
feat!: disable ssr by default

### DIFF
--- a/docs/content/en/1.get-started/2.config.md
+++ b/docs/content/en/1.get-started/2.config.md
@@ -15,6 +15,8 @@ export default {
   ],
   vite: {
     /* options for vite */
+    // ssr: true // enable unstable server-side rendering for development (false by default)
+    // experimentWarning: false // hide experimental warning message (disabled by default for tests)
     vue: {
       /* options for vite-plugin-vue2 */
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ function nuxtVite () {
   }
 
   // Disable SSR by default
-  const ssrEnabled = Boolean(nuxt.options.vite?.ssr)
+  const ssrEnabled = nuxt.options.ssr && nuxt.options.vite?.ssr
   if (!ssrEnabled) {
     nuxt.options.ssr = false
     nuxt.options.render.ssr = false

--- a/test/fixture/nuxt.config.js
+++ b/test/fixture/nuxt.config.js
@@ -22,5 +22,8 @@ export default {
         ssrContext.spa = true
       }
     }
+  },
+  vite: {
+    ssr: true
   }
 }


### PR DESCRIPTION
This PR disables server-side rendering by default when in vite mode. (development)

We have a working server implementation ([src](https://github.com/nuxt/vite/blob/main/src/server.ts)) based on vite's rollup production build but it is not a proper implementation and even [vite-plugin-vue2](https://github.com/underfin/vite-plugin-vue2) has not SSR support! (it is working by workaround) causing issues like #7, slower build times, and overall worst developer experience. 

The downside of doing this change is that it makes it harder to discover SSR issues (like hydration errors or module incompatibility) but makes it easier for adoption. For (`nuxt-vite`) development and tests, SSR is still enabled. Also, production builds use webpack for SSR so it only affects development.

New options: (`nuxt.config`)
- `vite.ssr` (boolean or vite ssr options)
- `vite.experimentWarning` (allows disabling banner)

![image](https://user-images.githubusercontent.com/5158436/117959228-1522f200-b31c-11eb-91c6-71ad0e98fea3.png)
