### PR TITLE
fix: hide warm-up errors

### DIFF
--- a/src/utils/warmup.ts
+++ b/src/utils/warmup.ts
@@ -1,4 +1,5 @@
 import type { ViteDevServer } from 'vite'
+import consola from 'consola'
 
 export async function warmupViteServer (server: ViteDevServer, entries: string[]) {
   const warmedUrls = new Set<String>()
@@ -6,7 +7,11 @@ export async function warmupViteServer (server: ViteDevServer, entries: string[]
   const warmup = async (url: string) => {
     if (warmedUrls.has(url)) { return undefined }
     warmedUrls.add(url)
-    await server.transformRequest(url)
+    try {
+      await server.transformRequest(url)
+    } catch (e) {
+      consola.debug('Warmup for %s failed with: %s', url, e)
+    }
     const deps = Array.from(server.moduleGraph.urlToModuleMap.get(url).importedModules)
     await Promise.all(deps.map(m => warmup(m.url)))
   }


### PR DESCRIPTION
On an app with Vuetify we were getting errors about undefined variables while warming up its scss files.

This change will consume those errors and log them as debug messages referencing the offending file.
