### PR TITLE
fix: use './static' as public dir for vite

### DIFF
--- a/src/vite.ts
+++ b/src/vite.ts
@@ -56,7 +56,7 @@ async function bundle (nuxt: Nuxt, builder: any) {
           jsxFactory: 'h',
           jsxFragment: 'Fragment'
         },
-        publicDir: resolve(nuxt.options.rootDir, nuxt.options.dir.assets),
+        publicDir: resolve(nuxt.options.rootDir, nuxt.options.dir.static),
         clearScreen: false,
         build: {
           emptyOutDir: false

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -56,7 +56,7 @@ async function bundle (nuxt: Nuxt, builder: any) {
           jsxFactory: 'h',
           jsxFragment: 'Fragment'
         },
-        publicDir: resolve(nuxt.options.rootDir, nuxt.options.dir.static),
+        publicDir: resolve(nuxt.options.srcDir, nuxt.options.dir.static),
         clearScreen: false,
         build: {
           emptyOutDir: false

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -56,6 +56,7 @@ async function bundle (nuxt: Nuxt, builder: any) {
           jsxFactory: 'h',
           jsxFragment: 'Fragment'
         },
+        publicDir: resolve(nuxt.options.rootDir, nuxt.options.dir.assets),
         clearScreen: false,
         build: {
           emptyOutDir: false


### PR DESCRIPTION
close #158