### PR TITLE
chore: fix hydration error in fixture

### DIFF
--- a/test/fixture/pages/capi.vue
+++ b/test/fixture/pages/capi.vue
@@ -3,6 +3,7 @@
     <h2>Hello Vite from Composition API!</h2>
     <pre v-text="injected" />
     <pre v-text="ssrRef" />
+    <nuxt-link to="/">/index</nuxt-link>
   </div>
 </template>
 

--- a/test/fixture/pages/index.vue
+++ b/test/fixture/pages/index.vue
@@ -1,21 +1,24 @@
 <template>
   <div>
     <h2>Hello Vite from Nuxt2!</h2>
-    <p><NormalComponent /></p>
-    <p><JSXComponent /></p>
-    <p><JSXHybrid /></p>
+    <div><NormalComponent /></div>
+    <div><JSXComponent /></div>
+    <div><JSXHybrid /></div>
     <pre v-text="stateText" />
+    <nuxt-link to="/capi">/capi</nuxt-link>
   </div>
 </template>
 
 <script>
 import JSXComponent from '~/components/JSXComponent'
 import JSXHybrid from '~/components/JSXHybrid'
+import NormalComponent from '~/components/NormalComponent'
 
 export default {
   components: {
     JSXComponent,
-    JSXHybrid
+    JSXHybrid,
+    NormalComponent
   },
   middleware: 'test-middleware',
   computed: {


### PR DESCRIPTION
fix hydration error in fixture. It looks like Vue is not happy with `<div>` inside of `<p>`, change to `<div>` works. Also the lazy load of NormalComponents causes a flicker on client hydration (not sure if it's intended), import it explicitly here.