### PR TITLE
docs(readme): Corrections to alt text and grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <p style="text-align: center">
-  <img src="./docs/static/preview.svg">
+  <img src="./docs/static/preview.svg" alt="Vite Experience with Nuxt 2. GitHub.com/nuxt/vite">
 </p>
 
-[![d](https://img.shields.io/npm/dm/nuxt-vite.svg?style=flat-square)](https://npmjs.com/package/nuxt-vite)
-[![v](https://img.shields.io/npm/v/nuxt-vite/latest.svg?style=flat-square)](https://npmjs.com/package/nuxt-vite)
-[![a](https://img.shields.io/github/workflow/status/nuxt/vite/ci/main?style=flat-square)](https://github.com/nuxt/vite/actions)
-[![c](https://img.shields.io/codecov/c/gh/nuxt/vite/main?style=flat-square)](https://codecov.io/gh/nuxt/vite)
+[![](https://img.shields.io/npm/dm/nuxt-vite.svg?style=flat-square)](https://npmjs.com/package/nuxt-vite)
+[![](https://img.shields.io/npm/v/nuxt-vite/latest.svg?style=flat-square)](https://npmjs.com/package/nuxt-vite)
+[![](https://img.shields.io/github/workflow/status/nuxt/vite/ci/main?style=flat-square)](https://github.com/nuxt/vite/actions)
+[![](https://img.shields.io/codecov/c/gh/nuxt/vite/main?style=flat-square)](https://codecov.io/gh/nuxt/vite)
 
 <!-- [![See Demo](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/nuxt/vite/tree/main/demo) -->
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
 <!-- [![See Demo](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/nuxt/vite/tree/main/demo) -->
 
 
-**🧪 Vite mode is experimental and many nuxt modules are still incompatible. If you find a bug, please report via [issues](https://github.com/nuxt/vite/issues) with a minimal reproduction.**
+**🧪 Vite mode is experimental and many Nuxt modules are still incompatible. If you find a bug, please report via [issues](https://github.com/nuxt/vite/issues) with a minimal reproduction.**
 
-💡 We are trying to make most of modules and options working out-of-the-box. If you are a module maintainer,
- please see [this section](https://vite.nuxtjs.org/advanced/modules) for supporting vite. If a module or feature is missing, feel free openining an issue.
+💡 We are trying to make most modules and options work out-of-the-box. If you are a module maintainer,
+ please see [this section](https://vite.nuxtjs.org/advanced/modules) for supporting Vite. If a module or feature is missing, feel free to open an issue.
 
 ## ⚡ Quick Start
 
@@ -36,7 +36,7 @@ export default {
 }
 ```
 
-That's it! Now you can enjoy super fast `nuxt dev` experience with Vite!
+That's it! Now you can enjoy a super fast `nuxt dev` experience with Vite!
 
 
 **[📖 Read documentation for more](https://vite.nuxtjs.org)**


### PR DESCRIPTION
- First image had missing alt text
- Badges had "d", "v", "a", and "c" which aren't as useful to screenreaders as empty "" alt text. Alt text like "Downloads per month", "Passing", etc without content of the actual values would also be less useful.