### PR TITLE
fix!: enabled SSR by default and opt-out experimental state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,25 +23,12 @@ function nuxtVite () {
     return
   }
 
-  // Disable SSR by default
-  const ssrEnabled = nuxt.options.ssr && nuxt.options.vite?.ssr
-  if (!ssrEnabled) {
-    nuxt.options.ssr = false
-    nuxt.options.render.ssr = false
-    nuxt.options.build.ssr = false
-    nuxt.options.mode = 'spa'
-  }
-
   nuxt.options.cli.badgeMessages.push(`⚡  Vite Mode Enabled (v${version})`)
   // eslint-disable-next-line no-console
   if (nuxt.options.vite?.experimentWarning !== false && !nuxt.options.test) {
     consola.log(
       '🧪  Vite mode is experimental and some nuxt modules might be incompatible\n',
-      '   If found a bug, please report via https://github.com/nuxt/vite/issues with a minimal reproduction.' + (
-        ssrEnabled
-          ? '\n    Unstable server-side rendering is enabled'
-          : '\n    You can enable unstable server-side rendering using `vite: { ssr: true }` in `nuxt.config`'
-      )
+      '   If found a bug, please report via https://github.com/nuxt/vite/issues with a minimal reproduction.'
     )
   }
 

--- a/test/fixture/nuxt.config.js
+++ b/test/fixture/nuxt.config.js
@@ -24,8 +24,8 @@ export default {
       }
     }
   },
+  ssr: true,
   vite: {
-    ssr: true,
     build: true,
     server: {
       fs: {


### PR DESCRIPTION
Resolved #185, Close #189

The problem of #185 is caused by the check ignores the check for `ssr: false` and will also disable the server for client build.

So I guess maybe we could take the chance to respect the `ssr: false` option in the top-level nuxt config. Giving the SSR has been improved quite a lot since the previous releases, plus this package itself is marked experimental anyway. I'd feel the SSR support is kinda good enough to not be the "experimental-in-experimental" thing. Which this change, this PR makes the behavior less confusing and a bit more robust.