### PR TITLE
fix: remove `/@id/` from defaultexport-handled ids

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -210,13 +210,7 @@ async function __vite_ssr_import__ (id) {
   if (__vite_import_cache__[id]) {
     return __vite_import_cache__[id]
   }
-  let mod = await $chunks[id]()
-  if (mod.default && typeof mod.default === 'object' && Object.keys(mod).length === 1) {
-    mod = mod.default
-  }
-  if (id.includes('.nuxt')) {
-    console.log({[id]: mod})
-  }
+  const mod = await $chunks[id]()
   if (mod && !('default' in mod)) {
     mod.default = mod
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -136,6 +136,10 @@ async function transformRequest (viteServer: vite.ViteDevServer, id) {
     id = '\0' + id.slice('/@id/__x00__'.length)
   }
 
+  if (id && id.startsWith('/@id/defaultexport')) {
+    id = id.slice('/@id/'.length)
+  }
+
   // Externals
   if (builtinModules.includes(id)) {
     return {
@@ -206,7 +210,13 @@ async function __vite_ssr_import__ (id) {
   if (__vite_import_cache__[id]) {
     return __vite_import_cache__[id]
   }
-  const mod = await $chunks[id]()
+  let mod = await $chunks[id]()
+  if (mod.default && typeof mod.default === 'object' && Object.keys(mod).length === 1) {
+    mod = mod.default
+  }
+  if (id.includes('.nuxt')) {
+    console.log({[id]: mod})
+  }
   if (mod && !('default' in mod)) {
     mod.default = mod
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -35,9 +35,9 @@ describe('dev', () => {
     testIndex(await get('/'))
   }).timeout(50000)
 
-  // it('Composition API works (SSR)', async () => {
-  //   testCompositionAPI(await get('/capi'))
-  // })
+  it('Composition API works (SSR)', async () => {
+    testCompositionAPI(await get('/capi'))
+  })
 
   it('Index works (SPA)', async () => {
     const page = await browser.newPage({ baseURL: url })


### PR DESCRIPTION
* no `defaultexport:` imports were loading on the server (this affected all plugins and hence the composition-api: https://github.com/nuxt/vite/pull/201#issuecomment-931598865)
* this PR removes `/@id/` so it can be handled as expected