### PR TITLE
fix: improve vite ssr import cache

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -206,7 +206,7 @@ const ${hashId(chunk.id)} = ${chunk.code}
 
   const dynamicImportCode = `
 const __vite_import_cache__ = Object.create({})
-async function __vite_ssr_import__(id) {
+function __vite_ssr_import__(id) {
   if (!__vite_import_cache__[id]) {
     __vite_import_cache__[id] = Promise.resolve($chunks[id]())
       .then(mod => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -206,16 +206,17 @@ const ${hashId(chunk.id)} = ${chunk.code}
 
   const dynamicImportCode = `
 const __vite_import_cache__ = Object.create({})
-async function __vite_ssr_import__ (id) {
-  if (__vite_import_cache__[id]) {
-    return __vite_import_cache__[id]
+async function __vite_ssr_import__(id) {
+  if (!__vite_import_cache__[id]) {
+    __vite_import_cache__[id] = Promise.resolve($chunks[id]())
+      .then(mod => {
+        if (mod && !('default' in mod)) {
+          mod.default = mod
+        }
+        return mod
+      })
   }
-  const mod = await $chunks[id]()
-  if (mod && !('default' in mod)) {
-    mod.default = mod
-  }
-  __vite_import_cache__[id] = mod
-  return mod
+  return __vite_import_cache__[id]
 }
 function __vite_ssr_dynamic_import__(id) {
   return __vite_ssr_import__(id)


### PR DESCRIPTION
The original cache will only be saved when the module gets resolved, which might lead to duplicated evaluation.

```ts
__vite_ssr_import__('a')
__vite_ssr_import__('a')
```

This PR improved the cache by saving the pending promise for each module to ensure that the same module always resolved to the same promise.