### PR TITLE
Update 1.installation.md

### DIFF
--- a/docs/content/en/1.getting-started/1.installation.md
+++ b/docs/content/en/1.getting-started/1.installation.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-Install `nuxt-vite`: (nuxt >= 2.15.0 is required)
+Install `nuxt-vite`: (nuxt >= 2.15.2 is required)
 
 ```sh
 yarn add --dev nuxt-vite


### PR DESCRIPTION
Now, nuxt >= 2.15.2 is required to use nuxt-vite.
![image](https://user-images.githubusercontent.com/32301380/202070880-2ff0a283-fe42-40a1-8b3c-2d80197464a4.png)
